### PR TITLE
Fix the physical memory allocator

### DIFF
--- a/kernel/memory/pmm.h
+++ b/kernel/memory/pmm.h
@@ -8,7 +8,6 @@
 #include <stddef.h>
 
 #define PAGE_SIZE 4096
-#define PHYSICAL_MEMORY_START 0x100000
 
 typedef struct
 {


### PR DESCRIPTION
`pmm_alloc()` was incorrectly located at the fixed address `0x100000`, which causes it to corrupt memory and cause unexpected behaviors